### PR TITLE
Evan: Slight adjustment of query in GetBudgetItems. 

### DIFF
--- a/Team_Budget/HomeBudget.cs
+++ b/Team_Budget/HomeBudget.cs
@@ -267,7 +267,7 @@ namespace Budget
                             "FROM expenses as e " +
                             "INNER JOIN categories as c " +
                             "ON e.CategoryId=c.Id " +
-                            $"WHERE e.Date>={startString} AND e.Date<={endString} ");
+                            $"WHERE e.Date>=\'{startString}\' AND e.Date<=\'{endString}\' ");
 
             if (FilterFlag)
             {


### PR DESCRIPTION
Date strings needed quotation marks; without them, query could not parse them. This change allows all remaining tests for GetBudgetItemsByCategory to pass (and will probably benefit tests for the other methods, too).