### PR TITLE
Grid selection after editing and deleting expenses

### DIFF
--- a/WpfHomeBudget/WpfHomeBudget/IViewable.cs
+++ b/WpfHomeBudget/WpfHomeBudget/IViewable.cs
@@ -38,5 +38,7 @@ namespace WpfHomeBudget
         // Change the color scheme to the colorfull one
 
         void turnLight();
+
+        void Select(int index);
     }
 }

--- a/WpfHomeBudget/WpfHomeBudget/MainWindow.xaml
+++ b/WpfHomeBudget/WpfHomeBudget/MainWindow.xaml
@@ -162,6 +162,10 @@
                             <MenuItem x:Name="deleteItem" Header="Delete" Click="deleteItem_Click"></MenuItem>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
+                    <DataGrid.Resources>
+                        <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}"  Color="{x:Static SystemColors.HighlightColor}"/>
+                        <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}"  Color="{x:Static SystemColors.HighlightTextColor}"/>
+                    </DataGrid.Resources>
                 </DataGrid>
 
                 <!-- options: row 2-->

--- a/WpfHomeBudget/WpfHomeBudget/MainWindow.xaml.cs
+++ b/WpfHomeBudget/WpfHomeBudget/MainWindow.xaml.cs
@@ -361,16 +361,19 @@ namespace WpfHomeBudget
         private void editItem_Click(object sender, RoutedEventArgs e)
         {
             var selected = mainDisplayGrid.SelectedItem as BudgetItem;
+            int index = mainDisplayGrid.SelectedIndex;
 
             EditExpenseWindow editExpenseWindow = new EditExpenseWindow(presenter, selected);
             editExpenseWindow.ShowDialog();
 
             UpdateGrid();
+            Select(index);
         }
 
         private void deleteItem_Click(object sender, RoutedEventArgs e)
         {
             var selected = mainDisplayGrid.SelectedItem as BudgetItem;
+            int index = mainDisplayGrid.SelectedIndex;
 
             if (MessageBox.Show(this, "Are you sure you want to delete this expense?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
             {
@@ -378,6 +381,7 @@ namespace WpfHomeBudget
             }
 
             UpdateGrid();
+            Select(index);
         }
 
         /// <summary>
@@ -400,6 +404,18 @@ namespace WpfHomeBudget
             {
                 editItem.IsEnabled = true;
                 deleteItem.IsEnabled = true;
+            }
+        }
+
+        /// <summary>
+        /// Sets focus to an item in the DataGrid.
+        /// </summary>
+        /// <param name="index">The index of item</param>
+        public void Select(int index)
+        {
+            if (!mainDisplayGrid.Items.IsEmpty && (mainDisplayGrid.Items[index] != null))
+            {
+                mainDisplayGrid.SelectedItem = mainDisplayGrid.Items[index];
             }
         }
     }


### PR DESCRIPTION
After editing an expense, the same row will stay selected.
After deleting an expense, the next (or final previous) row will be selected.