### PR TITLE
Add environment variable on nuget restore skips the setup project.

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -81,6 +81,8 @@ jobs:
       uses: warrenbuckley/Setup-Nuget@v1
       
     - name: Run Nuget.exe to restore NuGet packages
+      env:
+        RestoreUseSkipNonexistentTargets: false
       run: nuget restore $env:Solution_Name
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild


### PR DESCRIPTION
Set RestoreUseSkipNonexistentTargets to false